### PR TITLE
🚀 Task 2: Add CoNLL-Labeled Dataset and Validator Utility

### DIFF
--- a/src/annotation/convert_bio_to_parquet.py
+++ b/src/annotation/convert_bio_to_parquet.py
@@ -1,0 +1,117 @@
+# src/annotation/convert_bio_to_parquet.py
+
+"""
+Convert BIO-formatted labeled data to a structured Parquet file.
+Author: Teshager Admasu
+Date: 2025-06-19
+"""
+
+import logging
+import argparse
+from pathlib import Path
+from typing import List, Tuple
+
+import pandas as pd
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format="🔎 [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def parse_bio_file(file_path: Path) -> pd.DataFrame:
+    """
+    Parse a raw BIO-tagged file into a DataFrame.
+
+    Args:
+        file_path (Path): Path to the .txt file with BIO-tagged tokens.
+
+    Returns:
+        pd.DataFrame: Structured DataFrame with sentence_id, token, label.
+    """
+    tokens: List[str] = []
+    labels: List[str] = []
+    sentence_ids: List[int] = []
+
+    current_sentence: List[Tuple[str, str]] = []
+    sentence_id = 0
+
+    try:
+        with file_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+
+                if not line:  # New sentence
+                    if current_sentence:
+                        for token, label in current_sentence:
+                            tokens.append(token)
+                            labels.append(label)
+                            sentence_ids.append(sentence_id)
+                        sentence_id += 1
+                        current_sentence = []
+                else:
+                    try:
+                        token, label = line.rsplit(" ", 1)
+                        current_sentence.append((token, label))
+                    except ValueError:
+                        logger.warning(f"Skipping malformed line: '{line}'")
+
+            # Final sentence flush
+            if current_sentence:
+                for token, label in current_sentence:
+                    tokens.append(token)
+                    labels.append(label)
+                    sentence_ids.append(sentence_id)
+
+        logger.info(f"✅ Parsed {sentence_id + 1} sentences from {file_path.name}")
+        return pd.DataFrame(
+            {"sentence_id": sentence_ids, "token": tokens, "label": labels}
+        )
+
+    except FileNotFoundError:
+        logger.error(f"❌ File not found: {file_path}")
+        raise
+    except Exception as e:
+        logger.error(f"❌ Unexpected error while parsing: {e}")
+        raise
+
+
+def save_to_parquet(df: pd.DataFrame, output_path: Path):
+    """
+    Save DataFrame to a Parquet file.
+
+    Args:
+        df (pd.DataFrame): DataFrame to save.
+        output_path (Path): Output file path.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(output_path, index=False)
+    logger.info(f"📦 Saved structured data to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert BIO-tagged text file to Parquet format."
+    )
+    parser.add_argument(
+        "--input",
+        type=str,
+        required=True,
+        help="Path to the input .txt file with BIO-labeled data",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="data/processed/ner_annotations.parquet",
+        help="Path to save the output Parquet file",
+    )
+
+    args = parser.parse_args()
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    df = parse_bio_file(input_path)
+    save_to_parquet(df, output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/features/convert_to_conll.py
+++ b/src/features/convert_to_conll.py
@@ -1,0 +1,119 @@
+# src/features/convert_to_conll.py
+"""
+Convert labeled token/tag dataset to CoNLL-format .txt file for NER training.
+
+Author: Teshager Admasu
+Date: 2025-06-19
+"""
+
+import logging
+from pathlib import Path
+
+# from typing import List, Tuple
+import pandas as pd
+
+
+logging.basicConfig(level=logging.INFO, format="📦 [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def dataframe_to_conll(
+    df: pd.DataFrame,
+    token_col: str,
+    tag_col: str,
+    message_id_col: str,
+    output_path: Path,
+) -> None:
+    """
+    Convert labeled DataFrame to CoNLL format and save as .txt.
+
+    Args:
+        df (pd.DataFrame): DataFrame containing labeled tokens and tags.
+        token_col (str): Column name for tokens.
+        tag_col (str): Column name for NER tags.
+        message_id_col (str): Column name indicating message/sentence grouping.
+        output_path (Path): Output file path for CoNLL .txt file.
+
+    Raises:
+        ValueError: If required columns are missing.
+    """
+    required_cols = {token_col, tag_col, message_id_col}
+    missing_cols = required_cols - set(df.columns)
+    if missing_cols:
+        raise ValueError(f"Missing required columns: {missing_cols}")
+
+    logger.info(f"Converting DataFrame to CoNLL format at {output_path}")
+
+    with output_path.open("w", encoding="utf-8") as f:
+        current_msg_id = None
+        for _, row in df.iterrows():
+            msg_id = row[message_id_col]
+
+            # Blank line between messages
+            if msg_id != current_msg_id:
+                if current_msg_id is not None:
+                    f.write("\n")
+                current_msg_id = msg_id
+
+            token = str(row[token_col])
+            tag = str(row[tag_col])
+            f.write(f"{token} {tag}\n")
+
+    logger.info(f"Saved CoNLL-formatted file: {output_path}")
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Convert labeled data to CoNLL .txt format"
+    )
+    parser.add_argument(
+        "--input-csv",
+        type=Path,
+        required=True,
+        help="Input CSV file path with labeled tokens and tags",
+    )
+    parser.add_argument(
+        "--token-col",
+        type=str,
+        default="token",
+        help="Column name for tokens (default: token)",
+    )
+    parser.add_argument(
+        "--tag-col",
+        type=str,
+        default="tag",
+        help="Column name for NER tags (default: tag)",
+    )
+    parser.add_argument(
+        "--msg-id-col",
+        type=str,
+        default="message_id",
+        help="Column name to group tokens into messages/sentences"
+        " (default: message_id)",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        required=True,
+        help="Output file path for CoNLL .txt file",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        df = pd.read_csv(args.input_csv)
+        dataframe_to_conll(
+            df,
+            token_col=args.token_col,
+            tag_col=args.tag_col,
+            message_id_col=args.msg_id_col,
+            output_path=args.output_path,
+        )
+    except Exception as e:
+        logger.error(f"Failed to convert to CoNLL format: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/features/validate_conll.py
+++ b/src/features/validate_conll.py
@@ -1,0 +1,86 @@
+# src/features/validate_conll.py
+"""
+Validator for CoNLL-format .txt files for NER.
+
+Author: Teshager Admasu
+Date: 2025-06-19
+"""
+
+import logging
+from pathlib import Path
+import sys
+from typing import List
+
+logging.basicConfig(level=logging.INFO, format="📦 [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+VALID_BIO_PREFIXES = {"B-", "I-", "O"}
+
+
+def is_valid_bio_tag(tag: str) -> bool:
+    if tag == "O":
+        return True
+    if any(tag.startswith(prefix) for prefix in ("B-", "I-")):
+        return True
+    return False
+
+
+def validate_conll_file(file_path: Path) -> List[str]:
+    """
+    Validate a CoNLL file for well-formedness.
+
+    Args:
+        file_path (Path): Path to the CoNLL .txt file.
+
+    Returns:
+        List[str]: List of error messages found. Empty if no errors.
+    """
+    errors = []
+
+    with file_path.open("r", encoding="utf-8") as f:
+        for lineno, line in enumerate(f, start=1):
+            line = line.strip()
+
+            if line == "":
+                # Blank line separates sentences
+                continue
+
+            parts = line.split()
+            if len(parts) != 2:
+                errors.append(f"Line {lineno}: Expected 2 columns but got {len(parts)}")
+
+            else:
+                token, tag = parts
+                if not is_valid_bio_tag(tag):
+                    errors.append(f"Line {lineno}: Invalid BIO tag '{tag}'")
+
+    return errors
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Validate CoNLL .txt file for NER format"
+    )
+    parser.add_argument(
+        "file", type=Path, help="Path to CoNLL-format .txt file to validate"
+    )
+
+    args = parser.parse_args()
+
+    logger.info(f"Validating file: {args.file}")
+
+    errors = validate_conll_file(args.file)
+
+    if errors:
+        logger.error(f"Found {len(errors)} errors:")
+        for err in errors:
+            logger.error(f"  - {err}")
+        sys.exit(1)
+
+    logger.info("✅ No errors found. File is well-formed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 🚀 Task 2: Add CoNLL-Labeled Dataset and Validator Utility

This PR completes Task 2 of the Amharic Telegram E-Commerce NER project.

### ✅ What’s Included:
- Parsed the provided BIO-labeled data from `.txt` CoNLL format into a structured `DataFrame`
- Ensured conformance with CoNLL format (tokens per line, sentence splits via blank lines)
- Added validator to check that all lines are valid token-label pairs
- Saved final labeled data in `data/labelled/train.txt`

### 📂 Files Added
- `src/data/label_validator.py`: Utility to validate `.txt` CoNLL files
- `data/labelled/train.txt`: 30+ labeled messages in standard format

### 🔍 Issue Closed
Closes #3
